### PR TITLE
remove unused import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 
 var words = require('shellwords')
-var url = require('url')
 
 // TODO -F, --form
 // TODO --data-binary


### PR DESCRIPTION
This PR simply removes the unused import statement from `index.js`:

``` js
var url = require('url')
```
