### PR TITLE
Only split on first `: ` occurrence

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function rewrite(args) {
  */
 
 function parseField(s) {
-  return s.split(/: */)
+  return s.split(/: (.+)/)
 }
 
 /**


### PR DESCRIPTION
the headers came out wrong...

-H 'Origin: https://example.com' turned out to be `{Origin: 'https'}`