### PR TITLE
Use case-insensitive lookup for Content-Type header

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,6 @@ module.exports = exports.default = function(s) {
             break;
           case 'data':
             if (out.method == 'GET' || out.method == 'HEAD') out.method = 'POST'
-            out.header['Content-Type'] = out.header['Content-Type'] || 'application/x-www-form-urlencoded'
             out.body = out.body
               ? out.body + '&' + arg
               : arg
@@ -89,6 +88,16 @@ module.exports = exports.default = function(s) {
         break;
     }
   })
+
+  // Look for content-type using case-insensitive matching
+  var contentTypeMissing = out.body && Object.keys(out.header)
+    .filter(function (name) {
+      return name.toLowerCase() === 'content-type'
+    })
+    .length === 0
+  if (contentTypeMissing) {
+    out.header['Content-Type'] = 'application/x-www-form-urlencoded'
+  }
 
   return out
 }

--- a/test.js
+++ b/test.js
@@ -191,6 +191,16 @@ cases.push({
   }
 })
 
+cases.push({
+  input: "curl -H 'content-type: application/json' -d price=1 https://api.sloths.com",
+  output: {
+    method: 'POST',
+    url: 'https://api.sloths.com',
+    header: { 'content-type': 'application/json' },
+    body: "price=1"
+  }
+})
+
 cases.forEach(function(c){
   const out = parse(c.input)
 


### PR DESCRIPTION
Parse-curl uses a case-sensitive lookup for headers, I discovered a tiny problem with it.

If a curl command includes data e.g. `-d example=true`, curl will provide a default `'Content-Type': 'application/x-www-form-urlencoded'` header, but only if no `Content-Type`(case-insensitive) header is provided in the command. Currently, parse-curl will add the default header eagerly, even if a `content-type` header is provided later in the command. 

This PR fixes the module to follow the behavior of curl. I tried to follow the existing style (it was tempting to modernize).  