### PR TITLE
`Content-Type` and `content-type` both are identical

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = exports.default = function(s) {
             break;
           case 'data':
             if (out.method == 'GET' || out.method == 'HEAD') out.method = 'POST'
-            out.header['Content-Type'] = out.header['Content-Type'] || 'application/x-www-form-urlencoded'
+            out.header['Content-Type'] = out.header['Content-Type'] || out.header['content-type'] || 'application/x-www-form-urlencoded'
             out.body = out.body
               ? out.body + '&' + arg
               : arg

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = exports.default = function(s) {
             state = ''
             break;
           case 'user':
-            out.header['Authorization'] = 'Basic ' + window ? btoa(arg) : Buffer.from(arg).toString('base64')
+            out.header['Authorization'] = 'Basic ' + (typeof window !== 'undefined' ? btoa(arg) : Buffer.from(arg).toString('base64'))
             state = ''
             break;
           case 'method':

--- a/index.js
+++ b/index.js
@@ -67,7 +67,9 @@ module.exports = exports.default = function(s) {
             break;
           case 'data':
             if (out.method == 'GET' || out.method == 'HEAD') out.method = 'POST'
-            out.header['Content-Type'] = out.header['Content-Type'] || out.header['content-type'] || 'application/x-www-form-urlencoded'
+            if(!out.header['Content-Type'] || !out.header['content-type']) {
+              out.header['Content-Type'] = 'application/x-www-form-urlencoded';
+            }
             out.body = out.body
               ? out.body + '&' + arg
               : arg

--- a/index.js
+++ b/index.js
@@ -97,6 +97,11 @@ module.exports = exports.default = function (s) {
               out.header['Content-Type'] = 'application/x-www-form-urlencoded'
             }
             out.body = out.body ? out.body + '&' + arg : arg
+
+            if (
+              out.header['Content-Type'] === 'application/json'
+              || out.header['content-type'] === 'application/json'
+            ) out.body = out.body.replaceAll('\\"', '"')
             state = ''
             break
           case 'user':

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 var words = require('shellwords')
 
 // TODO -F, --form
@@ -10,50 +9,54 @@ var words = require('shellwords')
  * Attempt to parse the given curl string.
  */
 
-module.exports = exports.default = function(s) {
+module.exports = exports.default = function (s) {
   if (0 != s.indexOf('curl ')) return
   var args = rewrite(words.split(s))
   var out = { method: 'GET', header: {} }
   var state = ''
 
-  args.forEach(function(arg){
+  args.forEach(function (arg) {
     switch (true) {
       case isURL(arg):
         out.url = arg
-        break;
+        break
 
       case arg == '-A' || arg == '--user-agent':
         state = 'user-agent'
-        break;
+        break
 
       case arg == '-H' || arg == '--header':
         state = 'header'
-        break;
+        break
 
-      case arg == '-d' || arg == '--data' || arg == '--data-ascii' || arg == '--data-raw':
+      case arg == '-d' ||
+        arg == '--data' ||
+        arg == '--data-ascii' ||
+        arg == '--data-raw':
         state = 'data'
-        break;
+        break
 
       case arg == '-u' || arg == '--user':
         state = 'user'
-        break;
+        break
 
       case arg == '-I' || arg == '--head':
         out.method = 'HEAD'
-        break;
+        break
 
       case arg == '-X' || arg == '--request':
         state = 'method'
-        break;
+        break
 
-      case arg == '-b' || arg =='--cookie':
+      case arg == '-b' || arg == '--cookie':
         state = 'cookie'
-        break;
+        break
 
       case arg == '--compressed':
-        out.header['Accept-Encoding'] = out.header['Accept-Encoding'] || 'deflate, gzip'
-        break;
-      
+        out.header['Accept-Encoding'] =
+          out.header['Accept-Encoding'] || 'deflate, gzip'
+        break
+
       case arg == '-F' || arg == '--form':
         state = 'form'
         break
@@ -61,52 +64,55 @@ module.exports = exports.default = function(s) {
       case !!arg:
         switch (state) {
           case 'form':
-            if (!out.method || ['GET', 'HEAD'].includes(out.method) ) out.method = 'POST'
+            if (!out.method || ['GET', 'HEAD'].includes(out.method))
+              out.method = 'POST'
 
             out.header['Content-Type'] = 'multipart/form-data'
 
             const field = parseField(arg.replace(/\"/g, ''), '=')
-            
+
             if (typeof out.body !== 'object' || Object.keys(out.body) === 0) {
               out.body = {
-                [field[0]]: field[1]
+                [field[0]]: field[1],
               }
             } else out.body[field[0]] = field[1]
             state = ''
-            break;
+            break
           case 'header':
             field = parseField(arg, ': ')
             out.header[field[0]] = field[1]
             state = ''
-            break;
+            break
           case 'user-agent':
             out.header['User-Agent'] = arg
             state = ''
-            break;
+            break
           case 'data':
             if (out.method == 'GET' || out.method == 'HEAD') out.method = 'POST'
-            if(!out.header['Content-Type'] && !out.header['content-type']) {
-              out.header['Content-Type'] = 'application/x-www-form-urlencoded';
+            if (!out.header['Content-Type'] && !out.header['content-type']) {
+              out.header['Content-Type'] = 'application/x-www-form-urlencoded'
             }
-            out.body = out.body
-              ? out.body + '&' + arg
-              : arg
+            out.body = out.body ? out.body + '&' + arg : arg
             state = ''
-            break;
+            break
           case 'user':
-            out.header['Authorization'] = 'Basic ' + (typeof window !== 'undefined' ? btoa(arg) : Buffer.from(arg).toString('base64'))
+            out.header['Authorization'] =
+              'Basic ' +
+              (typeof window !== 'undefined'
+                ? btoa(arg)
+                : Buffer.from(arg).toString('base64'))
             state = ''
-            break;
+            break
           case 'method':
             out.method = arg
             state = ''
-            break;
+            break
           case 'cookie':
             out.header['Set-Cookie'] = arg
             state = ''
-            break;
+            break
         }
-        break;
+        break
     }
   })
 
@@ -118,7 +124,7 @@ module.exports = exports.default = function(s) {
  */
 
 function rewrite(args) {
-  return args.reduce(function(args, a){
+  return args.reduce(function (args, a) {
     if (0 == a.indexOf('-X')) {
       args.push('-X')
       args.push(a.slice(2))

--- a/index.js
+++ b/index.js
@@ -64,24 +64,28 @@ module.exports = exports.default = function (s) {
       case !!arg:
         switch (state) {
           case 'form':
-            if (!out.method || ['GET', 'HEAD'].includes(out.method))
-              out.method = 'POST'
+            {
+              if (!out.method || ['GET', 'HEAD'].includes(out.method))
+                out.method = 'POST'
 
-            out.header['Content-Type'] = 'multipart/form-data'
+              out.header['Content-Type'] = 'multipart/form-data'
 
-            const field = parseField(arg.replace(/\"/g, ''), '=')
+              const field = parseField(arg.replace(/\"/g, ''), '=')
 
-            if (typeof out.body !== 'object' || Object.keys(out.body) === 0) {
-              out.body = {
-                [field[0]]: field[1],
-              }
-            } else out.body[field[0]] = field[1]
-            state = ''
+              if (typeof out.body !== 'object' || Object.keys(out.body) === 0) {
+                out.body = {
+                  [field[0]]: field[1],
+                }
+              } else out.body[field[0]] = field[1]
+              state = ''
+            }
             break
           case 'header':
-            field = parseField(arg, ': ')
-            out.header[field[0]] = field[1]
-            state = ''
+            {
+              const field = parseField(arg, ': ')
+              out.header[field[0]] = field[1]
+              state = ''
+            }
             break
           case 'user-agent':
             out.header['User-Agent'] = arg

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = exports.default = function(s) {
             break;
           case 'data':
             if (out.method == 'GET' || out.method == 'HEAD') out.method = 'POST'
-            if(!out.header['Content-Type'] || !out.header['content-type']) {
+            if(!out.header['Content-Type'] && !out.header['content-type']) {
               out.header['Content-Type'] = 'application/x-www-form-urlencoded';
             }
             out.body = out.body

--- a/index.js
+++ b/index.js
@@ -98,6 +98,8 @@ module.exports = exports.default = function (s) {
             }
             out.body = out.body ? out.body + '&' + arg : arg
 
+            // Replace '\"' generated at the time of split string
+            // Which convert JSON string into the invalid format
             if (
               out.header['Content-Type'] === 'application/json'
               || out.header['content-type'] === 'application/json'

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = exports.default = function(s) {
             state = ''
             break;
           case 'user':
-            out.header['Authorization'] = 'Basic ' + btoa(arg)
+            out.header['Authorization'] = 'Basic ' + window ? btoa(arg) : Buffer.from(arg).toString('base64')
             state = ''
             break;
           case 'method':


### PR DESCRIPTION
`Content-Type` and `content-type` both are identical and should be considered the same header while parsing them.

#### For the given snippet
```
`curl --request POST \
      --url https://jsonplaceholder.typicode.com/posts \
      --header 'content-type: application/json' \
      --data '{ "userId": 1, "id": 1 }'`
```

#### current behavior is 
```js
{
  method: 'POST',
  header: {
    'content-typee': 'application/json',
    'Content-Type': 'application/x-www-form-urlencoded'
  },
  url: 'https://jsonplaceholder.typicode.com/posts',
  body: '{ "userId": 1, "id": 1 }'
}
```

#### Expected is
```js
{
  method: 'POST',
  header: { 'content-type': 'application/json' },
  url: 'https://jsonplaceholder.typicode.com/posts',
  body: '{ "userId": 1, "id": 1 }'
}
```

