### PR TITLE
Allow to generate basic auth in node environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = exports.default = function(s) {
             break;
           case 'data':
             if (out.method == 'GET' || out.method == 'HEAD') out.method = 'POST'
-            out.header['Content-Type'] = out.header['Content-Type'] || 'application/x-www-form-urlencoded'
+            out.header['Content-Type'] = out.header['Content-Type'] || out.header['content-type'] || 'application/x-www-form-urlencoded'
             out.body = out.body
               ? out.body + '&' + arg
               : arg

--- a/index.js
+++ b/index.js
@@ -67,7 +67,9 @@ module.exports = exports.default = function(s) {
             break;
           case 'data':
             if (out.method == 'GET' || out.method == 'HEAD') out.method = 'POST'
-            out.header['Content-Type'] = out.header['Content-Type'] || out.header['content-type'] || 'application/x-www-form-urlencoded'
+            if(!out.header['Content-Type'] || !out.header['content-type']) {
+              out.header['Content-Type'] = 'application/x-www-form-urlencoded';
+            }
             out.body = out.body
               ? out.body + '&' + arg
               : arg

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = exports.default = function(s) {
             break;
           case 'data':
             if (out.method == 'GET' || out.method == 'HEAD') out.method = 'POST'
-            if(!out.header['Content-Type'] || !out.header['content-type']) {
+            if(!out.header['Content-Type'] && !out.header['content-type']) {
               out.header['Content-Type'] = 'application/x-www-form-urlencoded';
             }
             out.body = out.body

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = exports.default = function(s) {
             state = ''
             break;
           case 'user':
-            out.header['Authorization'] = 'Basic ' + btoa(arg)
+            out.header['Authorization'] = 'Basic ' + window ? btoa(arg) : Buffer.from(arg).toString('base64')
             state = ''
             break;
           case 'method':


### PR DESCRIPTION
**Description**
- Allow to generating basic auth in node environment because `btoa` does not exist in node environment.

**Possible Solution**
`'Basic ' + window ? btoa(arg) : Buffer.from(arg).toString('base64')`